### PR TITLE
fix(docker): add extra_files to goreleaser docker config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,6 +63,9 @@ dockers:
     image_templates:
       - "ghcr.io/anowarislam/ado:{{ .Version }}-amd64"
       - "ghcr.io/anowarislam/ado:latest-amd64"
+    extra_files:
+      - LICENSE
+      - README.md
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.title={{ .ProjectName }}"
@@ -82,6 +85,9 @@ dockers:
     image_templates:
       - "ghcr.io/anowarislam/ado:{{ .Version }}-arm64"
       - "ghcr.io/anowarislam/ado:latest-arm64"
+    extra_files:
+      - LICENSE
+      - README.md
     build_flag_templates:
       - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.title={{ .ProjectName }}"


### PR DESCRIPTION
## Summary

Fixes GoReleaser Docker build failure in v1.1.0 release.

**Problem**: GoReleaser only includes the binary in its Docker build context by default. The `goreleaser.Dockerfile` includes `COPY LICENSE /LICENSE` and `COPY README.md /README.md`, but those files weren't available.

**Solution**: Add `extra_files` configuration to both docker image builds in `.goreleaser.yaml`.

## Test Plan

- [ ] Merge this PR
- [ ] Create v1.1.1 release (release-please will handle this)
- [ ] Verify Docker images are built and pushed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)