### PR TITLE
fix(ci): use GITHUB_TOKEN for Docker registry login

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -53,8 +53,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ steps.generate-token.outputs.token }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}  # App tokens can't push packages
 
       - name: Run goreleaser
         id: goreleaser


### PR DESCRIPTION
## Summary

Fixes the v1.1.2 GoReleaser Docker push failure.

## Problem

```
denied: permission_denied: installation not allowed to Create organization package
```

GitHub Apps **cannot push packages to ghcr.io** - this is a [known platform limitation](https://stackoverflow.com/questions/76821352).

## Solution

Use `secrets.GITHUB_TOKEN` for Docker login. The workflow already declares `packages:write` permission.

## Test Plan

- [ ] Merge this PR
- [ ] Re-trigger GoReleaser: `gh workflow run goreleaser.yml -f tag=v1.1.2`
- [ ] Verify Docker images on ghcr.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)