### PR TITLE
fix(ci): use input tag for cosign signing

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Sign container images
         env:
           REGISTRY: ghcr.io/anowarislam/ado
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
           # Sign by tag (multiple tags point to same manifest)
           cosign sign --yes "${REGISTRY}:${TAG}"


### PR DESCRIPTION
## Summary

Fixes cosign container signing when using workflow_dispatch.

## Problem

When triggered via `workflow_dispatch`, `github.ref_name` resolves to `main` (the branch), not the release tag. This caused cosign to look for `ghcr.io/anowarislam/ado:main` which doesn't exist.

## Solution

Use the same pattern as the checkout step:
```yaml
TAG: ${{ github.event.inputs.tag || github.ref_name }}
```

## Test Plan

- [ ] Merge this PR
- [ ] Re-trigger: `gh workflow run goreleaser.yml -f tag=v1.1.2`
- [ ] Verify cosign signing succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)