### PR TITLE
fix(ci): strip v prefix from tag for cosign signing

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -81,8 +81,9 @@ jobs:
       - name: Sign container images
         env:
           REGISTRY: ghcr.io/anowarislam/ado
-          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          GIT_TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
-          # Sign by tag (multiple tags point to same manifest)
-          cosign sign --yes "${REGISTRY}:${TAG}"
+          # Strip 'v' prefix - GoReleaser tags images as 1.2.3, not v1.2.3
+          VERSION="${GIT_TAG#v}"
+          cosign sign --yes "${REGISTRY}:${VERSION}"
           cosign sign --yes "${REGISTRY}:latest"


### PR DESCRIPTION
## Summary

Fixes cosign container signing failing with "manifest unknown".

## Problem

- Git tags: `v1.1.3`
- Docker image tags: `1.1.3` (GoReleaser strips the `v` prefix)

Cosign was looking for `ghcr.io/anowarislam/ado:v1.1.3` but the image is `ghcr.io/anowarislam/ado:1.1.3`.

## Solution

Strip the `v` prefix from the git tag before signing:
```bash
VERSION="${GIT_TAG#v}"
cosign sign --yes "${REGISTRY}:${VERSION}"
```

## Test Plan

- [ ] Merge this PR
- [ ] Merge the release-please PR (v1.1.4)
- [ ] Verify cosign signing succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)