### PR TITLE
docs: integrate three-phase workflow across documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ Thank you for your interest in contributing to `ado`! This document provides gui
 
 ## Quick Links
 
+- [Development Workflow](docs/workflow.md) - Issue → ADR → Spec → Implementation
 - [Code of Conduct](CODE_OF_CONDUCT.md)
 - [Security Policy](SECURITY.md)
 - [Detailed Contributing Guide](docs/contributing.md)
@@ -35,10 +36,25 @@ make test
 
 ## Development Workflow
 
+This project uses a **three-phase workflow** for significant changes:
+
+1. **Decision (ADR)** - For architectural changes, create an ADR first
+2. **Specification** - Write spec before implementation (command or feature)
+3. **Implementation** - Code, tests, docs
+
+See [workflow.md](docs/workflow.md) for the complete guide with examples.
+
 ### 1. Create a Branch
 
 ```bash
-git checkout -b feature/your-feature-name
+# For ADRs
+git checkout -b adr/NNNN-short-title
+
+# For specs
+git checkout -b spec/feature-name
+
+# For implementation
+git checkout -b feat/your-feature-name
 # or
 git checkout -b fix/your-bug-fix
 ```
@@ -48,6 +64,7 @@ git checkout -b fix/your-bug-fix
 - Follow the [Go Style Guide](docs/style/go-style.md)
 - Write tests for new functionality
 - Update documentation if needed
+- For new commands: create spec first ([template](docs/commands/TEMPLATE.md))
 
 ### 3. Validate Locally
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,6 +2,24 @@
 
 This document covers conventions for contributing to the `ado` project.
 
+## Development Workflow
+
+This project uses a three-phase development process: **Issue → ADR → Spec → Implementation**
+
+| Change Type | Path |
+|-------------|------|
+| Architectural change | ADR first (`docs/adr/`) |
+| New command | Spec first (`docs/commands/`) |
+| New internal feature | Spec first (`docs/features/`) |
+| Bug fix | Direct to implementation |
+
+**PR sequence for significant features:**
+1. **PR 1 (ADR)**: `docs(adr): NNNN - title` (if architectural)
+2. **PR 2 (Spec)**: `docs(spec): [command\|feature] name`
+3. **PR 3 (Code)**: `feat(scope): description`
+
+See [workflow.md](workflow.md) for the complete guide with examples.
+
 ## Commit Conventions
 
 This project uses [Conventional Commits](https://www.conventionalcommits.org/) enforced by git hooks and CI.
@@ -95,14 +113,17 @@ func TestResolveConfigPath(t *testing.T) {
 
 ## Adding New Commands
 
-This project is **spec-driven**:
+This project is **spec-driven** with a structured workflow:
 
-1. Create spec in `docs/commands/<command>.md` first
-2. Prototype in `lab/py/` if logic is complex
-3. Implement in Go under `cmd/ado/<command>/`
-4. Export `NewCommand() *cobra.Command`
-5. Wire into `cmd/ado/root/root.go`
-6. Write table-driven tests
+1. **Create issue** using the command proposal template (`.github/ISSUE_TEMPLATE/command_proposal.md`)
+2. **Create spec** in `docs/commands/<command>.md` using [TEMPLATE.md](commands/TEMPLATE.md)
+3. Prototype in `lab/py/` if logic is complex (optional)
+4. Implement in Go under `cmd/ado/<command>/`
+5. Export `NewCommand() *cobra.Command`
+6. Wire into `cmd/ado/root/root.go`
+7. Write table-driven tests
+
+For commands requiring architectural changes (new patterns, new dependencies), create an ADR first. See [workflow.md](workflow.md) for decision criteria.
 
 ## Code Constraints
 

--- a/docs/style/docs-style.md
+++ b/docs/style/docs-style.md
@@ -1,12 +1,24 @@
 # Documentation Style Guide
 
-Guidelines for writing and maintaining project documentation: command specs, README, and design docs.
+Guidelines for writing and maintaining project documentation: ADRs, specs, README, and design docs.
 
 ## Philosophy
 - Documentation is the specification; code implements the spec.
 - Examples beat prose; show concrete CLI invocations with expected output.
 - Keep docs synchronized with code; outdated docs are worse than no docs.
 - Write for future maintainers; assume no prior context.
+
+## Documentation Types
+
+This project uses three types of specification documents:
+
+| Type | Location | Purpose | Template |
+|------|----------|---------|----------|
+| **ADR** | `docs/adr/` | Why decisions were made | [TEMPLATE.md](../adr/TEMPLATE.md) |
+| **Feature Spec** | `docs/features/` | What internal features do | [TEMPLATE.md](../features/TEMPLATE.md) |
+| **Command Spec** | `docs/commands/` | What CLI commands do | [TEMPLATE.md](../commands/TEMPLATE.md) |
+
+See [workflow.md](../workflow.md) for when to create each type.
 
 ## Command Specifications (`docs/commands/*.md`)
 
@@ -112,6 +124,69 @@ Document:
 - Empty/malformed config files
 - Permission errors
 - Network failures (if applicable)
+
+## Architecture Decision Records (`docs/adr/*.md`)
+
+ADRs document significant architectural decisions with context, consequences, and alternatives.
+
+### When to Write an ADR
+
+Required for:
+- New architectural patterns
+- Breaking changes to existing patterns
+- Adding new dependencies or tools
+- Security-related decisions
+- Changes affecting multiple components
+
+Not required for bug fixes, single commands following existing patterns, or documentation.
+
+### Structure
+
+Copy [TEMPLATE.md](../adr/TEMPLATE.md) to `NNNN-title.md`. Key sections:
+
+1. **Context** - Why is this decision needed now?
+2. **Decision** - What is the decision? Be specific.
+3. **Consequences** - What are the trade-offs (positive and negative)?
+4. **Alternatives Considered** - What else was evaluated?
+
+### Content Guidelines
+
+- Be specific about the problem being solved
+- Include concrete examples where helpful
+- Link to related ADRs when decisions interact
+- Update status promptly (Proposed → Accepted)
+
+See [docs/adr/README.md](../adr/README.md) for complete process.
+
+## Feature Specifications (`docs/features/*.md`)
+
+Feature specs document non-command functionality: configuration systems, logging, plugins, internal libraries.
+
+### When to Write a Feature Spec
+
+Use for internal capabilities that aren't direct CLI commands:
+- Configuration validation and loading
+- Plugin discovery and loading
+- Logging and telemetry infrastructure
+- Shared utilities consumed by multiple commands
+
+### Structure
+
+Copy [TEMPLATE.md](../features/TEMPLATE.md) to `NN-feature-name.md`. Key sections:
+
+1. **Motivation** - What problem does this solve? Who benefits?
+2. **Specification** - Behavior, configuration, API/interfaces
+3. **Examples** - Concrete usage examples
+4. **Testing Strategy** - Unit tests, integration tests, manual checklist
+
+### Content Guidelines
+
+- Focus on behavior, not implementation details
+- Include code snippets for API examples
+- Document error cases and edge cases
+- Link to ADR if architectural decision preceded this
+
+See [docs/features/README.md](../features/README.md) for complete process.
 
 ## README Maintenance
 
@@ -238,16 +313,26 @@ Design docs capture architectural decisions and specifications before implementa
 
 ## Synchronization Checklist
 
-When making changes, update docs in this order:
+When making changes, update docs in this order. See [workflow.md](../workflow.md) for the complete process.
 
 ### Adding a New Command
 
-1. ✅ Create `docs/commands/<NN>-<command>.md` with full spec
-2. ✅ Update `README.md` "Initial Commands" section if it's user-facing
-3. ✅ Update `CLAUDE.md` "Current Command Set" if implementation is complete
-4. ✅ Implement in `cmd/ado/<command>/<command>.go`
-5. ✅ Add tests; ensure examples in spec work
-6. ✅ Update `AGENTS.md` if workflow changes (new Make targets, etc.)
+1. ✅ Create issue with `command_proposal.md` template
+2. ✅ (If architectural) Create ADR in `docs/adr/NNNN-title.md`
+3. ✅ Create spec in `docs/commands/<NN>-<command>.md` using template
+4. ✅ Update `README.md` "Usage" section if user-facing
+5. ✅ Implement in `cmd/ado/<command>/<command>.go`
+6. ✅ Add tests; ensure examples in spec work
+7. ✅ Update `CLAUDE.md` if patterns change
+
+### Adding a New Feature (non-command)
+
+1. ✅ Create issue with `feature_proposal.md` template
+2. ✅ (If architectural) Create ADR in `docs/adr/NNNN-title.md`
+3. ✅ Create spec in `docs/features/<NN>-<feature>.md` using template
+4. ✅ Implement in `internal/<package>/`
+5. ✅ Add tests matching spec's testing strategy
+6. ✅ Update `CLAUDE.md` if patterns change
 
 ### Changing Command Behavior
 


### PR DESCRIPTION
## Summary

Completes PR 3 of 3 for implementing ADR-0001: Development Workflow

This PR integrates the three-phase workflow (Issue → ADR → Spec → Implementation) into all contributing documentation:

- **docs/contributing.md**: Add workflow overview section, update "Adding New Commands" to include issue creation and spec-first approach
- **docs/style/docs-style.md**: Add Documentation Types table, ADR and Feature Spec sections with guidelines, update synchronization checklist
- **CONTRIBUTING.md**: Add workflow quick link, update branch naming to include adr/ and spec/ prefixes, add three-phase workflow overview

## Related PRs

| PR | Status | Description |
|----|--------|-------------|
| #31 | Merged | PR 1: ADR Framework |
| #33 | Merged | PR 2: Specification Framework |
| **#34** | This PR | PR 3: Workflow Integration |

## Test Plan

- [x] `make docs.build` passes (no warnings in strict mode)
- [x] All internal links resolve correctly
- [x] Documentation is consistent across all files

🤖 Generated with [Claude Code](https://claude.com/claude-code)