### PR TITLE
docs(adr): 0002 - structured logging

### DIFF
--- a/docs/adr/0002-structured-logging.md
+++ b/docs/adr/0002-structured-logging.md
@@ -1,0 +1,137 @@
+# ADR-0002: Structured Logging
+
+| Metadata | Value |
+|----------|-------|
+| **Status** | Proposed |
+| **Date** | 2024-11-26 |
+| **Author(s)** | @anowarislam |
+| **Issue** | #37 |
+| **Related ADRs** | N/A |
+
+## Context
+
+The `ado` CLI currently uses ad-hoc `fmt.Println` and `fmt.Fprintf` calls for output. This approach has several limitations:
+
+- **No log levels**: Cannot distinguish debug output from errors
+- **Not structured**: Cannot parse output in automated pipelines
+- **No timestamps**: Difficult to correlate events
+- **Inconsistent format**: Different commands format output differently
+- **No configuration**: Cannot control verbosity at runtime
+
+As `ado` grows, we need a consistent logging infrastructure that:
+
+1. Supports log levels (Debug, Info, Warn, Error)
+2. Provides structured output (JSON) for machine consumption
+3. Defaults to human-readable output in terminals
+4. Is configurable via config file and CLI flags
+5. Maintains minimal dependencies
+
+## Decision
+
+**We will use Go's standard library `log/slog` package** for structured logging in `ado`.
+
+Key implementation details:
+
+1. **Logger Interface**: Define a thin interface in `internal/logging` wrapping `slog`
+2. **Default Handler**: Text format for TTY, JSON for non-TTY (auto-detect)
+3. **Configuration**: Support via `~/.config/ado/config.yaml` and `--log-level` flag
+4. **Levels**: Debug, Info, Warn, Error (matching slog's built-in levels)
+5. **Context Fields**: Support structured fields for machine-readable logs
+
+```go
+// Usage example
+log := logging.New(cfg)
+log.Info("validating config", "path", configPath)
+log.Debug("parsed yaml", "keys", len(rawMap))
+log.Error("validation failed", "error", err)
+```
+
+## Consequences
+
+### Positive
+
+- **Zero dependencies**: `log/slog` is in Go's stdlib (1.21+), no external packages needed
+- **Official solution**: Maintained by the Go team, well-documented, stable API
+- **Structured by design**: Key-value attributes are first-class citizens
+- **Flexible handlers**: Easy to switch between text/JSON output
+- **Future-proof**: As the official Go logging solution, it will continue to evolve
+- **Performance**: Designed to be allocation-efficient
+
+### Negative
+
+- **Go 1.21+ required**: Already satisfied (ado requires Go 1.23+)
+- **Less features than third-party**: No built-in log rotation, file output requires custom handler
+- **Learning curve**: Developers familiar with zerolog/zap may need adjustment
+
+### Neutral
+
+- **API style**: Uses `slog.Info("msg", "key", value)` vs `zerolog`'s fluent `.Str("key", value).Msg("msg")`
+- **Handler system**: Custom handlers can be added for advanced use cases
+
+## Alternatives Considered
+
+### Alternative 1: zerolog
+
+**Description:** Zero-allocation JSON logger, extremely fast, fluent API.
+
+```go
+log.Info().Str("path", configPath).Msg("validating config")
+```
+
+**Why not chosen:**
+- Adds external dependency
+- Performance gains not meaningful for CLI (not high-throughput server)
+- Fluent API is more verbose than slog's variadic approach
+- slog is now the official Go solution
+
+### Alternative 2: zap
+
+**Description:** Uber's structured, leveled logging library. Battle-tested in production.
+
+```go
+logger.Info("validating config", zap.String("path", configPath))
+```
+
+**Why not chosen:**
+- Adds external dependency
+- More complex API (need to call `zap.String()`, `zap.Int()`, etc.)
+- Designed for server-side high-performance logging
+- Overkill for a CLI tool
+
+### Alternative 3: Keep using fmt.Println
+
+**Description:** Continue with current approach, no structured logging.
+
+**Why not chosen:**
+- Cannot implement log levels
+- Cannot provide JSON output for pipelines
+- Cannot configure verbosity
+- Does not solve the original problem
+
+## Implementation Notes
+
+After approval, implement in two phases:
+
+1. **Spec**: `docs/features/01-structured-logging.md`
+   - Define Logger interface
+   - Specify configuration options
+   - Document output formats
+
+2. **Implementation**: `internal/logging/`
+   - `logger.go`: Logger interface and implementation
+   - `handler.go`: Custom handlers (auto-detect TTY)
+   - `config.go`: Configuration integration
+   - Tests for all components
+
+Integration with existing code:
+- Add `logging.Logger` to command context
+- Gradually replace `fmt.Println` with structured log calls
+- Preserve user-facing output (results) separate from logs
+
+## References
+
+- [Go slog package documentation](https://pkg.go.dev/log/slog)
+- [Go blog: Structured Logging with slog](https://go.dev/blog/slog)
+- [Issue #37: Feature: Structured Logging](https://github.com/anowarislam/ado/issues/37)
+- [zerolog](https://github.com/rs/zerolog) - Alternative considered
+- [zap](https://github.com/uber-go/zap) - Alternative considered

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,7 @@ An ADR is a document that captures an important architectural decision along wit
 | ID | Title | Status | Date |
 |----|-------|--------|------|
 | [0001](0001-development-workflow.md) | ADR + Spec Development Workflow | Accepted | 2025-11-25 |
+| [0002](0002-structured-logging.md) | Structured Logging | Proposed | 2025-11-26 |
 
 ## ADR Lifecycle
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ nav:
       - ADRs:
           - Overview: adr/README.md
           - "0001: Development Workflow": adr/0001-development-workflow.md
+          - "0002: Structured Logging": adr/0002-structured-logging.md
       - Feature Specs:
           - Overview: features/README.md
   - Contributing:


### PR DESCRIPTION
## Summary

- Propose using Go's stdlib `log/slog` for structured logging
- ADR-0002: Document decision rationale and alternatives considered
- Add to ADR index and mkdocs navigation

## Decision

**Use `log/slog`** (Go 1.21+ stdlib) for structured logging.

### Why slog?

| Factor | slog | zerolog | zap |
|--------|------|---------|-----|
| Dependencies | Zero | External | External |
| Maintenance | Go team | Community | Uber |
| Performance | Good | Best | Great |
| CLI suitability | Perfect | Overkill | Overkill |

### Key Points

1. Zero dependencies - keeps binary small
2. Official Go solution - stable, well-documented API
3. Structured by design - key-value attributes first-class
4. Flexible handlers - text for TTY, JSON for pipelines
5. Go 1.21+ required - already satisfied (ado uses 1.23+)

## Checklist

- [x] ADR follows template structure
- [x] Context clearly explains the problem
- [x] Decision is clearly stated
- [x] Alternatives are documented with rationale
- [x] Consequences (positive/negative) are realistic
- [x] Links to originating Issue
- [x] Added to `docs/adr/README.md` index
- [x] Added to `mkdocs.yml` navigation

## Next Steps

After approval:
1. Update ADR status to "Accepted"
2. Create feature spec (Phase 2): `docs/features/01-structured-logging.md`
3. Implement (Phase 3): `internal/logging/`

Resolves architectural decision for #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)