### PR TITLE
docs(spec): feature structured-logging

### DIFF
--- a/docs/adr/0002-structured-logging.md
+++ b/docs/adr/0002-structured-logging.md
@@ -2,8 +2,8 @@
 
 | Metadata | Value |
 |----------|-------|
-| **Status** | Proposed |
-| **Date** | 2024-11-26 |
+| **Status** | Accepted |
+| **Date** | 2025-11-26 |
 | **Author(s)** | @anowarislam |
 | **Issue** | #37 |
 | **Related ADRs** | N/A |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,7 +16,7 @@ An ADR is a document that captures an important architectural decision along wit
 | ID | Title | Status | Date |
 |----|-------|--------|------|
 | [0001](0001-development-workflow.md) | ADR + Spec Development Workflow | Accepted | 2025-11-25 |
-| [0002](0002-structured-logging.md) | Structured Logging | Proposed | 2025-11-26 |
+| [0002](0002-structured-logging.md) | Structured Logging | Accepted | 2025-11-26 |
 
 ## ADR Lifecycle
 

--- a/docs/features/01-structured-logging.md
+++ b/docs/features/01-structured-logging.md
@@ -1,0 +1,252 @@
+# Feature: Structured Logging
+
+| Metadata | Value |
+|----------|-------|
+| **ADR** | [ADR-0002](../adr/0002-structured-logging.md) |
+| **Status** | Draft |
+| **Issue** | #37 |
+| **Author(s)** | @anowarislam |
+
+## Overview
+
+Structured logging infrastructure using Go's `log/slog` package, providing leveled logging with configurable output formats for both human readability and machine consumption.
+
+## Motivation
+
+Why is this feature needed? What problem does it solve?
+
+- **Pain point**: Current ad-hoc `fmt.Println` calls provide no log levels, timestamps, or structure
+- **Who benefits**:
+  - Developers debugging issues (log levels)
+  - Operators monitoring in production (structured JSON)
+  - CI pipelines parsing output (machine-readable)
+- **Without this**: Inconsistent output, difficult debugging, unusable in automated systems
+
+## Specification
+
+### Behavior
+
+1. **Logger Initialization**
+   - Create logger from config at startup
+   - Auto-detect TTY for format selection (text vs JSON)
+   - Respect `--log-level` flag override
+
+2. **Log Levels** (ascending severity)
+   - `Debug`: Verbose debugging information
+   - `Info`: General operational messages (default)
+   - `Warn`: Potential issues that don't stop execution
+   - `Error`: Failures that affect functionality
+
+3. **Output Formats**
+   - **Text** (default for TTY): Human-readable, colored output
+   - **JSON** (default for non-TTY): Machine-parseable structured logs
+
+4. **Structured Fields**
+   - All log calls support key-value pairs
+   - Keys are strings, values can be any type
+   - Fields are formatted based on output mode
+
+### Configuration
+
+```yaml
+# Example config in ~/.config/ado/config.yaml
+version: 1
+logging:
+  level: info      # debug, info, warn, error
+  format: auto     # auto, text, json
+  output: stderr   # stderr, stdout
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `logging.level` | string | `info` | Minimum log level to output |
+| `logging.format` | string | `auto` | Output format (auto detects TTY) |
+| `logging.output` | string | `stderr` | Output destination |
+
+### CLI Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--log-level` | string | from config | Override log level |
+
+### API/Interface
+
+```go
+// Package logging provides structured logging for ado.
+package logging
+
+import "log/slog"
+
+// Logger provides structured, leveled logging.
+type Logger interface {
+    // Debug logs at debug level with optional structured fields.
+    Debug(msg string, args ...any)
+
+    // Info logs at info level with optional structured fields.
+    Info(msg string, args ...any)
+
+    // Warn logs at warn level with optional structured fields.
+    Warn(msg string, args ...any)
+
+    // Error logs at error level with optional structured fields.
+    Error(msg string, args ...any)
+
+    // With returns a new Logger with the given attributes.
+    With(args ...any) Logger
+
+    // Handler returns the underlying slog.Handler.
+    Handler() slog.Handler
+}
+
+// Config holds logging configuration.
+type Config struct {
+    Level  string // debug, info, warn, error
+    Format string // auto, text, json
+    Output string // stderr, stdout
+}
+
+// New creates a new Logger from the given configuration.
+func New(cfg Config) Logger
+
+// NewFromConfig creates a Logger from the application config.
+func NewFromConfig(appCfg *config.Config) Logger
+
+// Default returns the default logger (info level, auto format, stderr).
+func Default() Logger
+```
+
+### File Locations
+
+| Purpose | Path |
+|---------|------|
+| Main implementation | `internal/logging/logger.go` |
+| Configuration | `internal/logging/config.go` |
+| Handlers | `internal/logging/handler.go` |
+| Tests | `internal/logging/*_test.go` |
+
+## Examples
+
+### Example 1: Basic Usage
+
+```go
+// In a command
+log := logging.New(logging.Config{Level: "info", Format: "auto"})
+
+log.Info("validating config", "path", "/home/user/.config/ado/config.yaml")
+// Text output (TTY):
+// INFO validating config path=/home/user/.config/ado/config.yaml
+//
+// JSON output (non-TTY):
+// {"level":"INFO","msg":"validating config","path":"/home/user/.config/ado/config.yaml"}
+
+log.Debug("parsed yaml", "keys", 3)
+// (not shown at info level)
+
+log.Error("validation failed", "error", "missing version")
+// Text output:
+// ERROR validation failed error="missing version"
+```
+
+### Example 2: Using With() for Context
+
+```go
+// Add persistent context
+cmdLog := log.With("command", "config", "subcommand", "validate")
+
+cmdLog.Info("starting validation")
+// {"level":"INFO","msg":"starting validation","command":"config","subcommand":"validate"}
+
+cmdLog.Debug("checking file", "path", path)
+// {"level":"DEBUG","msg":"checking file","command":"config","subcommand":"validate","path":"..."}
+```
+
+### Example 3: CLI Flag Override
+
+```bash
+# Run with debug logging
+ado --log-level debug config validate
+
+# Output includes debug messages:
+# DEBUG resolving config path sources=[XDG_CONFIG_HOME, ~/.config/ado, ~/.ado]
+# DEBUG found config file path=/home/user/.config/ado/config.yaml
+# INFO validating config path=/home/user/.config/ado/config.yaml
+```
+
+### Example 4: Configuration File
+
+```yaml
+# ~/.config/ado/config.yaml
+version: 1
+logging:
+  level: debug
+  format: json
+  output: stderr
+```
+
+```bash
+ado config validate
+# All output in JSON format, including debug messages
+```
+
+## Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|------------------|
+| Invalid log level in config | Default to "info", log warning |
+| Invalid format in config | Default to "auto", log warning |
+| No config file | Use defaults (info, auto, stderr) |
+| `--log-level` flag | Overrides config file setting |
+| TTY detection fails | Default to text format |
+| Nil logger | Panic with clear error (programming error) |
+
+## Testing Strategy
+
+### Unit Tests
+
+- [ ] Test level filtering (debug messages hidden at info level)
+- [ ] Test text output format
+- [ ] Test JSON output format
+- [ ] Test TTY auto-detection
+- [ ] Test With() creates new logger with context
+- [ ] Test config parsing and defaults
+- [ ] Test invalid config values fall back to defaults
+
+### Integration Tests
+
+- [ ] Test end-to-end with config file
+- [ ] Test `--log-level` flag override
+- [ ] Test JSON output is parseable
+
+### Manual Testing Checklist
+
+- [ ] Run `ado config validate` and verify output format
+- [ ] Run with `--log-level debug` and verify debug messages appear
+- [ ] Pipe output to a file and verify JSON format
+- [ ] Run in terminal and verify text format with colors
+
+## Implementation Checklist
+
+- [ ] Create `internal/logging/` package
+- [ ] Implement `Logger` interface wrapping `slog.Logger`
+- [ ] Implement `Config` struct and parsing
+- [ ] Implement TTY detection for auto format
+- [ ] Create text handler with optional colors
+- [ ] Create JSON handler
+- [ ] Add `logging` section to config schema
+- [ ] Add `--log-level` flag to root command
+- [ ] Write unit tests (target: 80% coverage)
+- [ ] Write integration tests
+- [ ] Update CLAUDE.md with new package
+
+## Open Questions
+
+Resolved by ADR-0002:
+
+- [x] Which logging library? **Answer: log/slog (stdlib)**
+- [x] External dependencies? **Answer: None needed**
+
+## Changelog
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2025-11-26 | Initial draft | @anowarislam |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -19,7 +19,7 @@ For CLI command specifications, see [`docs/commands/`](../commands/).
 
 | ID | Title | Status | ADR |
 |----|-------|--------|-----|
-| *(none yet)* | | | |
+| [01](01-structured-logging.md) | Structured Logging | Draft | [ADR-0002](../adr/0002-structured-logging.md) |
 
 ## Creating a Feature Spec
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
           - "0002: Structured Logging": adr/0002-structured-logging.md
       - Feature Specs:
           - Overview: features/README.md
+          - "01: Structured Logging": features/01-structured-logging.md
   - Contributing:
       - Guide: contributing.md
       - Style Guides:


### PR DESCRIPTION
## Summary

- Create feature specification for structured logging infrastructure
- Update ADR-0002 status from Proposed to Accepted
- Add to feature specs index and mkdocs navigation

## Specification Highlights

### Logger Interface

```go
type Logger interface {
    Debug(msg string, args ...any)
    Info(msg string, args ...any)
    Warn(msg string, args ...any)
    Error(msg string, args ...any)
    With(args ...any) Logger
}
```

### Configuration

```yaml
logging:
  level: info      # debug, info, warn, error
  format: auto     # auto, text, json
  output: stderr   # stderr, stdout
```

### Key Features

- Uses Go's stdlib `log/slog` (zero dependencies per ADR-0002)
- Auto-detect TTY for format selection
- CLI flag override: `--log-level`
- Structured fields for machine-readable logs

## Checklist

- [x] Spec follows template structure
- [x] Examples are concrete and testable
- [x] Error cases documented with expected behavior
- [x] Implementation locations specified
- [x] Testing strategy defined
- [x] Links to ADR (ADR-0002)
- [x] Links to originating Issue (#37)
- [x] Added to feature specs index
- [x] Added to `mkdocs.yml` navigation

## Phase Sequence

| Phase | Status | Artifact |
|-------|--------|----------|
| 0. Issue | Created | #37 |
| 1. ADR | Merged | PR #40, ADR-0002 |
| 2. Spec | This PR | `docs/features/01-structured-logging.md` |
| 3. Implementation | Next | `internal/logging/` |

Implements spec phase for #37
References: ADR-0002

🤖 Generated with [Claude Code](https://claude.com/claude-code)