### PR TITLE
feat(dist): add Homebrew distribution via in-repo tap

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -109,3 +109,49 @@ docker_manifests:
     image_templates:
       - "ghcr.io/anowarislam/ado:latest-amd64"
       - "ghcr.io/anowarislam/ado:latest-arm64"
+
+# Homebrew Formula (in-repository tap)
+# See: https://goreleaser.com/customization/homebrew/
+brews:
+  - # Repository configuration - same repo, no separate token needed
+    repository:
+      owner: anowarislam
+      name: ado  # Same repository
+      branch: main
+      # Note: Uses default GITHUB_TOKEN from workflow (no separate token needed)
+
+    # Formula directory in same repository
+    folder: Formula
+
+    # Formula metadata
+    name: ado
+    homepage: https://github.com/anowarislam/ado
+    description: "Composable command-line binary to replace ad-hoc shell scripts"
+    license: MIT
+
+    # Post-installation message
+    caveats: |
+      Get started with ado by running:
+        ado meta info
+
+      Configuration: ~/.config/ado/config.yaml
+      Documentation: https://github.com/anowarislam/ado
+
+    # Git commit configuration
+    commit_author:
+      name: ado-releaser
+      email: noreply@github.com
+
+    commit_msg_template: "chore(brew): update formula to {{ .Tag }}"
+
+    # Skip upload for snapshot builds (local testing only)
+    skip_upload: auto
+
+    # Test block (Homebrew requirement)
+    test: |
+      system "#{bin}/ado", "meta", "info"
+      assert_match version.to_s, shell_output("#{bin}/ado meta info")
+
+    # Installation from bottle (precompiled binary)
+    install: |
+      bin.install "ado"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,26 @@ The project is built around two ideas:
 
 ## Installation
 
+### Homebrew (macOS & Linux)
+
+**Recommended for macOS users**
+
+```bash
+# Add the tap (one-time setup)
+brew tap anowarislam/ado
+
+# Install ado
+brew install ado
+
+# Verify installation
+ado meta info
+```
+
+**Updating:**
+```bash
+brew upgrade ado
+```
+
 ### Binary Download
 
 Download pre-built binaries from the [GitHub Releases](https://github.com/anowarislam/ado/releases) page.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,6 +2,52 @@
 
 Multiple installation methods are available for `ado`.
 
+## Homebrew (macOS & Linux)
+
+**Recommended installation method for macOS users.**
+
+Homebrew provides automatic updates, dependency management, and clean uninstallation.
+
+### Installation
+
+```bash
+# First-time setup: add the ado tap
+brew tap anowarislam/ado
+
+# Install ado
+brew install ado
+
+# Verify installation
+ado meta info
+```
+
+### Supported Platforms
+
+- macOS (Intel and Apple Silicon)
+- Linux with Homebrew (Linuxbrew)
+
+### Updating
+
+```bash
+# Check for updates
+brew outdated
+
+# Upgrade ado
+brew upgrade ado
+```
+
+### Uninstalling
+
+```bash
+# Uninstall ado
+brew uninstall ado
+
+# Remove tap (optional)
+brew untap anowarislam/ado
+```
+
+---
+
 ## Binary Download
 
 Download pre-built binaries from the [GitHub Releases](https://github.com/anowarislam/ado/releases) page.


### PR DESCRIPTION
## Summary

Implements Homebrew distribution for `ado` CLI via in-repository tap.

Users can install with:
```bash
brew tap anowarislam/ado
brew install ado
```

## Changes

- ✅ Created `Formula/` directory for Homebrew formulae
- ✅ Added `brews` configuration to `.goreleaser.yaml`
- ✅ Updated `README.md` with Homebrew installation
- ✅ Updated `docs/installation.md` with Homebrew as primary for macOS
- ✅ No changes needed to GitHub Actions (token already configured)

## Implementation Details

- **Tap type:** In-repository tap (Formula/ in same repo)
- **Token:** Uses existing GitHub App token from GoReleaser workflow
- **Automation:** Formula auto-generated and committed on each release
- **Testing:** Pre-push checks passed (tests, coverage 83.5%, build, docs)

## Testing Plan

- [x] Pre-push checks passed (tests, formatting, coverage, build, docs)
- [x] GoReleaser configuration validated (brews section syntax)
- [ ] Post-merge: Verify formula committed on next release
- [ ] Post-merge: Test `brew tap` + `brew install` flow
- [ ] Post-merge: Test `brew upgrade` on subsequent release

## Post-Merge Validation

After the first release with this change:
1. Verify `Formula/ado.rb` is committed to repository
2. Test installation: `brew tap anowarislam/ado && brew install ado`
3. Verify: `ado meta info` shows correct version
4. Test upgrade flow on next release

## References

- Spec: `docs/features/02-homebrew-distribution.md`
- Issue: #54
- GoReleaser docs: https://goreleaser.com/customization/homebrew/